### PR TITLE
perf: reduce copying when sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Current benchmark status with 8 CPU(s) Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
 
 | Name                         | Total         | Adverage      | Min           | Max           |
 | ---------------------------- | ------------- | ------------- | ------------- | ------------- |
-| ivy_match(file.lua) 1000000x | 02.351614 (s) | 00.000002 (s) | 00.000002 (s) | 00.000042 (s) |
-| ivy_files(kubneties) 100x    | 32.704256 (s) | 00.327043 (s) | 00.289397 (s) | 00.344413 (s) |
+| ivy_match(file.lua) 1000000x | 02.353386 (s) | 00.000002 (s) | 00.000002 (s) | 00.000049 (s) |
+| ivy_files(kubneties) 100x    | 24.809576 (s) | 00.248096 (s) | 00.203167 (s) | 00.270263 (s) |
 
 ## Other stuff you might like
 

--- a/cpp/sorter.hpp
+++ b/cpp/sorter.hpp
@@ -20,7 +20,7 @@ class Sorter {
 
     if (score > -200) {
       std::unique_lock<std::mutex> lock(m_matches_lock);
-      m_matches.emplace_back(Match{score, file});
+      m_matches.emplace_back(Match{score, std::move(file)});
     }
   }
 
@@ -28,9 +28,9 @@ class Sorter {
   explicit Sorter(std::string_view term) : m_term(term) {}
   ~Sorter() { m_thread_pool.shutdown(); }
 
-  inline std::vector<Match> sort(std::vector<std::string> list) {
-    for (auto item : list) {
-      m_thread_pool.push([item, this]() { add_entry(item); });
+  inline std::vector<Match> sort(const std::vector<std::string>& list) {
+    for (const std::string& item : list) {
+      m_thread_pool.push([&item, this]() { add_entry(item); });
     }
 
     while (!m_thread_pool.empty()) {


### PR DESCRIPTION
Passes values by reference when sorting to reduce memory copying. The
main saving on this is preventing copying of the large vector of files
getting passed into the `sort` function and then copying each item in
the vector in the for. This results in about a 27% performance gain
reducing the full benchmark of the kubernetes benchmark by 7.89 sec

Before

| Name                         | Total         | Average       | Min           | Max           |
| ---------------------------- | ------------- | ------------- | ------------- | ------------- |
| ivy_match(file.lua) 1000000x | 02.351614 (s) | 00.000002 (s) | 00.000002 (s) | 00.000042 (s) |
| ivy_files(kubernetes) 100x   | 32.704256 (s) | 00.327043 (s) | 00.289397 (s) | 00.344413 (s) |

After

| Name                         | Total         | Average       | Min           | Max           |
| ---------------------------- | ------------- | ------------- | ------------- | ------------- |
| ivy_match(file.lua) 1000000x | 02.353386 (s) | 00.000002 (s) | 00.000002 (s) | 00.000049 (s) |
| ivy_files(kubernetes) 100x   | 24.809576 (s) | 00.248096 (s) | 00.203167 (s) | 00.270263 (s) |