### PR TITLE
feat: make the completion candidates type more consistent

### DIFF
--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -11,7 +11,8 @@ controller.run = function(name, items, callback)
   controller.items = items
 
   window.initialize()
-  window.set_items { "-- Loading ---" }
+
+  window.set_items { { content = "-- Loading ---"  } }
   vim.api.nvim_buf_set_name(window.get_buffer(), name)
 
   controller.input ""

--- a/plugin/ivy.lua
+++ b/plugin/ivy.lua
@@ -30,13 +30,13 @@ vim.api.nvim_create_user_command("IvyBuffers", function()
       if vim.api.nvim_buf_is_loaded(buffer) and #buffer_name > 0 then
         local score = libivy.ivy_match(input, buffer_name)
         if score > -200 or #input == 0 then
-          table.insert(list, { score, buffer_name })
+          table.insert(list, { score = score, content = buffer_name })
         end
       end
     end
 
     table.sort(list, function(a, b)
-      return a[1] < b[1]
+      return a.score < b.score
     end)
 
     return list


### PR DESCRIPTION
The API for `window.set_items` took to many variable types. It would
take a table in multiple different formats and a string. Now it will
only take a table in a single format and a string. It will convert the
string into the table format by splitting it on new lines.

The table format is an array of tables that must have a `content` key
that will be the text that is displayed in the completion window. The
table can have any other data that is ignored.

```lua
local items = {
  { content = "Item one" },
  { content = "Item two" }
}
```

The `set_items` function will only display the `content` key in the
completion window, it will not do any sorting or filtering, that must be
done before passing the data to the `set_items` function.