### PR TITLE
fix: include dot files in search results

### DIFF
--- a/lua/ivy/libivy.lua
+++ b/lua/ivy/libivy.lua
@@ -8,6 +8,7 @@ local ivy_c = ffi.load(library_path)
 
 ffi.cdef [[
     void ivy_init(const char*);
+    char* ivy_cwd();
     int ivy_match(const char*, const char*);
     char* ivy_files(const char*, const char*);
 ]]
@@ -16,6 +17,10 @@ local libivy = {}
 
 libivy.ivy_init = function(dir)
   ivy_c.ivy_init(dir)
+end
+
+libivy.ivy_cwd = function ()
+  return  ffi.string(ivy_c.ivy_cwd())
 end
 
 libivy.ivy_match = function(pattern, text)

--- a/lua/ivy/libivy_test.lua
+++ b/lua/ivy/libivy_test.lua
@@ -7,3 +7,12 @@ it("should run a simple match", function(t)
     t.error("Score should not be less than 0 found " .. score)
   end
 end)
+
+it("should find a dot file", function (t)
+  local current_dir = libivy.ivy_cwd()
+  local matches = libivy.ivy_files("ci.yml", current_dir);
+
+  if matches ~= ".github/workflows/ci.yml\n" then
+    t.error("Invalid matches: " .. matches)
+  end
+end);

--- a/rust/finder.rs
+++ b/rust/finder.rs
@@ -1,4 +1,4 @@
-use ignore::WalkBuilder;
+use ignore::{overrides::OverrideBuilder, WalkBuilder};
 use std::fs;
 
 pub struct Options {
@@ -10,7 +10,15 @@ pub fn find_files(options: Options) -> Vec<String> {
     let base_path = &fs::canonicalize(options.directory).unwrap();
 
     let mut builder = WalkBuilder::new(base_path);
-    builder.ignore(true).hidden(true);
+    builder.hidden(false);
+
+    // TODO(ade): Remove unwraps and find a good way to get the errors into the UI. Currently there
+    // is no way to handel errors in the rust library
+    let mut override_builder = OverrideBuilder::new("");
+    override_builder.add("!.git").unwrap();
+
+    let overrides = override_builder.build().unwrap();
+    builder.overrides(overrides);
 
     for result in builder.build() {
         let absolute_candidate = result.unwrap();

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -41,6 +41,13 @@ pub extern "C" fn ivy_init(c_base_dir: *const c_char) {
 }
 
 #[no_mangle]
+pub extern "C" fn ivy_cwd() -> *const c_char {
+    return CString::new(std::env::current_dir().unwrap().to_str().unwrap())
+        .unwrap()
+        .into_raw();
+}
+
+#[no_mangle]
 pub extern "C" fn ivy_match(c_pattern: *const c_char, c_text: *const c_char) -> c_int {
     let pattern = to_string(c_pattern);
     let text = to_string(c_text);


### PR DESCRIPTION
This adds dot files into the finder. We are adding the overrides to the
`ignore` package, that can be used later to add custom ignore
directories that can be passed in as settings.

We are also adding a new `ivy_cwd` function to libivy to get the current
directory due to the limitations of lua.

Fixes-issue: #16