### PR TITLE
fix: ensure the correct window is activated on complete

### DIFF
--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -37,7 +37,9 @@ controller.update = function(text)
 end
 
 controller.complete = function()
-  controller.checkpoint()
+  vim.api.nvim_set_current_win(window.origin)
+  controller.callback(window.get_current_selection())
+
   controller.destroy()
 end
 

--- a/lua/ivy/window_test.lua
+++ b/lua/ivy/window_test.lua
@@ -1,0 +1,30 @@
+local window = require "ivy.window"
+
+before_each(function()
+  -- Mock the global vim functions we are using in the prompt
+  _G.vim = {
+    notify = function() end,
+    api = {
+      nvim_echo = function() end,
+      nvim_get_current_win = function()
+        return 10
+      end,
+      nvim_command = function() end,
+      nvim_win_get_buf = function()
+        return 10
+      end,
+      nvim_win_set_option = function() end,
+      nvim_buf_set_option = function() end,
+      nvim_buf_set_var = function() end,
+      nvim_buf_set_keymap = function() end,
+    },
+  }
+end)
+
+it("can initialize", function(t)
+  window.initialize()
+
+  if window.get_buffer() ~= 10 then
+    t.error("The windows buffer should be 10 found " .. window.get_buffer())
+  end
+end)


### PR DESCRIPTION
When you complete a completion the completion window is no longer
activated after the callback is run. This was causing issues with the
incorrect window being active after the completion.

This will lead the way for more actions other then edit, that will be
coming soon.

Fixes-issue: #8
