### PR TITLE
feat: add vsplit and split actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ A command can be run that will launch the completion UI
 
 Action can be run on selected candidates provide functionality
 
-| Action   | Description                                                                    |
-| -------- | ------------------------------------------------------------------------------ |
-| Complete | Run the completion function, usually this will be opening a file               |
-| Peek     | Run the completion function on a selection, but don't close the results window |
+| Action         | Description                                                                    |
+| -------------- | ------------------------------------------------------------------------------ |
+| Complete       | Run the completion function, usually this will be opening a file               |
+| Peek           | Run the completion function on a selection, but don't close the results window |
+| Vertical Split | Run the completion function in a new vertical split                            |
+| Split          | Run the completion function in a new split                                     |
 
 ## API
 

--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -1,7 +1,9 @@
 local window = require "ivy.window"
 local prompt = require "ivy.prompt"
+local utils = require "ivy.utils"
 
 local controller = {}
+controller.action = utils.actions
 
 controller.items = nil
 controller.callback = nil
@@ -36,16 +38,16 @@ controller.update = function(text)
   end)
 end
 
-controller.complete = function()
+controller.complete = function(action)
   vim.api.nvim_set_current_win(window.origin)
-  controller.callback(window.get_current_selection())
+  controller.callback(window.get_current_selection(), action)
 
   controller.destroy()
 end
 
 controller.checkpoint = function()
   vim.api.nvim_set_current_win(window.origin)
-  controller.callback(window.get_current_selection())
+  controller.callback(window.get_current_selection(), controller.action.CHECKPOINT)
   vim.api.nvim_set_current_win(window.window)
 end
 

--- a/lua/ivy/prompt_test.lua
+++ b/lua/ivy/prompt_test.lua
@@ -1,14 +1,8 @@
 local prompt = require "ivy.prompt"
+local vim_mock = require "ivy.vim_mock"
 
 before_each(function()
-  -- Mock the global vim functions we are using in the prompt
-  _G.vim = {
-    notify = function() end,
-    api = {
-      nvim_echo = function() end,
-    },
-  }
-
+  vim_mock.reset()
   prompt.destroy()
 end)
 
@@ -23,7 +17,7 @@ end
 local assert_prompt = function(t, expected)
   local text = prompt.text()
   if text ~= expected then
-    t.error("The promp text should be '" .. expected .. "' found '" .. text .. "'")
+    t.error("The prompt text should be '" .. expected .. "' found '" .. text .. "'")
   end
 end
 

--- a/lua/ivy/utils_line_action_test.lua
+++ b/lua/ivy/utils_line_action_test.lua
@@ -1,0 +1,39 @@
+local utils = require "ivy.utils"
+local line_action = utils.line_action()
+local vim_mock = require "ivy.vim_mock"
+
+before_each(function()
+  vim_mock.reset()
+end)
+
+it("will run the line command", function(t)
+  line_action " 4: Some text"
+
+  if #vim_mock.commands ~= 1 then
+    t.error "`line_action` command length should be 1"
+  end
+
+  if vim_mock.commands[1] ~= "4" then
+    t.error "`line_action` command should be 4"
+  end
+end)
+
+it("will run with more numbers", function(t)
+  line_action " 44: Some text"
+
+  if #vim_mock.commands ~= 1 then
+    t.error "`line_action` command length should be 1"
+  end
+
+  if vim_mock.commands[1] ~= "44" then
+    t.error "`line_action` command should be 44"
+  end
+end)
+
+it("dose not run any action if no line is found", function(t)
+  line_action "Some text"
+
+  if #vim_mock.commands ~= 0 then
+    t.error "`line_action` command length should be 1"
+  end
+end)

--- a/lua/ivy/utils_vimgrep_action_test.lua
+++ b/lua/ivy/utils_vimgrep_action_test.lua
@@ -1,0 +1,56 @@
+local utils = require "ivy.utils"
+local vimgrep_action = utils.vimgrep_action()
+local vim_mock = require "ivy.vim_mock"
+
+before_each(function()
+  vim_mock.reset()
+end)
+
+local test_data = {
+  {
+    it = "will edit some file and goto the line",
+    completion = "some/file.lua:2: This is some text",
+    action = utils.actions.EDIT,
+    commands = {
+      "edit some/file.lua",
+      "2",
+    },
+  },
+  {
+    it = "will skip the line if its not matched",
+    completion = "some/file.lua: This is some text",
+    action = utils.actions.EDIT,
+    commands = { "edit some/file.lua" },
+  },
+  {
+    it = "will run the vsplit command",
+    completion = "some/file.lua: This is some text",
+    action = utils.actions.VSPLIT,
+    commands = { "vsplit some/file.lua" },
+  },
+  {
+    it = "will run the split command",
+    completion = "some/file.lua: This is some text",
+    action = utils.actions.SPLIT,
+    commands = { "split some/file.lua" },
+  },
+}
+
+for i = 1, #test_data do
+  local data = test_data[i]
+  it(data.it, function(t)
+    vimgrep_action(data.completion, data.action)
+
+    if #vim_mock.commands ~= #data.commands then
+      t.error("Incorrect number of commands run expected " .. #data.commands .. " but found " .. #vim_mock.commands)
+    end
+
+    for j = 1, #data.commands do
+      if vim_mock.commands[j] ~= data.commands[j] then
+        t.error(
+          "Incorrect command run expected '" .. data.commands[j] .. "' but found '" .. vim_mock.commands[j] .. "'"
+        )
+      end
+    end
+  end)
+end

--- a/lua/ivy/vim_mock.lua
+++ b/lua/ivy/vim_mock.lua
@@ -1,0 +1,30 @@
+local mock = {
+  commands = {},
+}
+
+mock.reset = function()
+  mock.commands = {}
+
+  _G.vim = {
+    notify = function() end,
+    cmd = function(cmd)
+      table.insert(mock.commands, cmd)
+    end,
+    api = {
+      nvim_echo = function() end,
+      nvim_get_current_win = function()
+        return 10
+      end,
+      nvim_command = function() end,
+      nvim_win_get_buf = function()
+        return 10
+      end,
+      nvim_win_set_option = function() end,
+      nvim_buf_set_option = function() end,
+      nvim_buf_set_var = function() end,
+      nvim_buf_set_keymap = function() end,
+    },
+  }
+end
+
+return mock

--- a/lua/ivy/window.lua
+++ b/lua/ivy/window.lua
@@ -69,7 +69,9 @@ window.make_buffer = function()
     "<cmd>lua vim.ivy.previous(); vim.ivy.checkpoint()<CR>",
     opts
   )
-  vim.api.nvim_buf_set_keymap(window.buffer, "n", "<CR>", "<cmd>lua vim.ivy.complete()<CR>", opts)
+  vim.api.nvim_buf_set_keymap(window.buffer, "n", "<CR>", "<cmd>lua vim.ivy.complete(vim.ivy.action.EDIT)<CR>", opts)
+  vim.api.nvim_buf_set_keymap(window.buffer, "n", "<C-v>", "<cmd>lua vim.ivy.complete(vim.ivy.action.VSPLIT)<CR>", opts)
+  vim.api.nvim_buf_set_keymap(window.buffer, "n", "<C-s>", "<cmd>lua vim.ivy.complete(vim.ivy.action.SPLIT)<CR>", opts)
   vim.api.nvim_buf_set_keymap(window.buffer, "n", "<BS>", "<cmd>lua vim.ivy.input('BACKSPACE')<CR>", opts)
   vim.api.nvim_buf_set_keymap(window.buffer, "n", "<Left>", "<cmd>lua vim.ivy.input('LEFT')<CR>", opts)
   vim.api.nvim_buf_set_keymap(window.buffer, "n", "<Right>", "<cmd>lua vim.ivy.input('RIGHT')<CR>", opts)

--- a/lua/ivy/window_test.lua
+++ b/lua/ivy/window_test.lua
@@ -1,24 +1,8 @@
+local vim_mock = require "ivy.vim_mock"
 local window = require "ivy.window"
 
 before_each(function()
-  -- Mock the global vim functions we are using in the prompt
-  _G.vim = {
-    notify = function() end,
-    api = {
-      nvim_echo = function() end,
-      nvim_get_current_win = function()
-        return 10
-      end,
-      nvim_command = function() end,
-      nvim_win_get_buf = function()
-        return 10
-      end,
-      nvim_win_set_option = function() end,
-      nvim_buf_set_option = function() end,
-      nvim_buf_set_var = function() end,
-      nvim_buf_set_keymap = function() end,
-    },
-  }
+  vim_mock.reset()
 end)
 
 it("can initialize", function(t)


### PR DESCRIPTION
Now you can open the currently selected item in a vertical split or a horizontal split. The completion callback must support the current actions.

There is also a bit of testing in here. The vim mock has been refactored and split out, so we can use it in multiple tests.