### PR TITLE
fix: exscpe test when passing it to vim syntax match

### DIFF
--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -34,7 +34,12 @@ controller.update = function(text)
   vim.schedule(function()
     window.set_items(controller.items(text))
     vim.cmd "syntax clear IvyMatch"
-    vim.cmd("syntax match IvyMatch '[(" .. text .. ")]'")
+    if #text > 0 then
+      -- Escape characters so they do not throw an error when vim tries to use
+      -- the "text" as a regex
+      local escaped_text = string.gsub(text, "([-/])", "\\%1")
+      vim.cmd("syntax match IvyMatch '[" .. escaped_text .. "]'")
+    end
   end)
 end
 

--- a/lua/ivy/controller_test.lua
+++ b/lua/ivy/controller_test.lua
@@ -1,0 +1,51 @@
+local vim_mock = require "ivy.vim_mock"
+local window = require "ivy.window"
+local controller = require "ivy.controller"
+
+-- The number of the mock buffer where all the test completions gets put
+local buffer_number = 10
+
+before_each(function()
+  vim_mock.reset()
+  window.initialize()
+end)
+
+after_each(function()
+  controller.destroy()
+end)
+
+it("will run", function(t)
+  controller.run("Testing", function()
+    return { { content = "Some content" } }
+  end, function()
+    return {}
+  end)
+
+  local lines = vim_mock.get_lines()
+  local completion_lines = lines[buffer_number]
+
+  t.assert_equal(#completion_lines, 1)
+  t.assert_equal(completion_lines[1], "Some content")
+end)
+
+it("will not try and highlight the buffer if there is nothing to highlight", function(t)
+  controller.items = function()
+    return { { content = "Hello" } }
+  end
+
+  controller.update ""
+  local commands = vim_mock.get_commands()
+  t.assert_equal(#commands, 1)
+end)
+
+it("will escape a - when passing it to be highlighted", function(t)
+  controller.items = function()
+    return { { content = "Hello" } }
+  end
+
+  controller.update "some-file"
+  local commands = vim_mock.get_commands()
+  local syntax_command = commands[2]
+
+  t.assert_equal("syntax match IvyMatch '[some\\-file]'", syntax_command)
+end)

--- a/lua/ivy/vim_mock.lua
+++ b/lua/ivy/vim_mock.lua
@@ -4,6 +4,14 @@ local mock = {
   cursors = {},
 }
 
+mock.get_lines = function()
+  return mock.lines
+end
+
+mock.get_commands = function()
+  return mock.commands
+end
+
 mock.reset = function()
   mock.commands = {}
   mock.lines = {}
@@ -25,6 +33,7 @@ mock.reset = function()
       end,
       nvim_win_set_option = function() end,
       nvim_buf_set_option = function() end,
+      nvim_buf_set_name = function() end,
       nvim_buf_set_var = function() end,
       nvim_buf_set_keymap = function() end,
       nvim_buf_delete = function() end,
@@ -66,6 +75,9 @@ mock.reset = function()
         return lines
       end,
     },
+    schedule = function(callback)
+      callback()
+    end,
   }
 end
 

--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -55,7 +55,7 @@ _G.it = function(name, callback)
   local status, err = pcall(callback, context)
   local elapsed = (os.clock() * 1000) - time
 
-  call_hook "before_each"
+  call_hook "after_each"
 
   local prefix = "\x1B[42mPASS"
   global_context.total = global_context.total + 1

--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -57,14 +57,14 @@ _G.it = function(name, callback)
 
   call_hook "after_each"
 
-  local prefix = "\x1B[42mPASS"
+  local prefix = "\x1B[42m\x1B[30m PASS "
   global_context.total = global_context.total + 1
 
   if status then
     global_context.pass = global_context.pass + 1
   else
     global_context.fail = global_context.fail + 1
-    prefix = "\x1B[41mFAIL"
+    prefix = "\x1B[41m\x1B[30m FAIL "
   end
 
   print(string.format("%s\x1B[0m %s - %s (%.3f ms)", prefix, global_context.current_test_name, name, elapsed))


### PR DESCRIPTION
This was causing an issue in an invalid regex. Now we are escaping the
text to make it a valid regex.

There is also a small improvement where we no longer try to highlight
matched words if the "text" is empty.

Ref: https://github.com/AdeAttwood/ivy.nvim/issues/26