### PR TITLE
ci: move to the dockerhub conventional-tools update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,20 +5,6 @@ on:
   pull_request: { branches: ["0.x"] }
 
 jobs:
-  commits:
-    name: Commitlint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1000
-
-      - name: Lint commits
-        uses: docker://registry.k1.zportal.co.uk/practically-oss/conventional-tools:0.x
-        with:
-          args: conventional-tools commitlint -l1 -f39febd82e236a9c79f5b408e98cbd20410f11e9e
-
   luacheck:
     name: Luacheck
     runs-on: ubuntu-latest

--- a/.github/workflows/ct-commitlint.yml
+++ b/.github/workflows/ct-commitlint.yml
@@ -1,0 +1,21 @@
+name: Conventional Tools Commitlint
+
+on:
+  push: { branches: ["0.x"] }
+  pull_request: { branches: ["0.x"] }
+
+jobs:
+  commits:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    container: practically/conventional-tools:1.x@sha256:e0603c12e8b4b835c9fcceaa4ddad4077ccf223665c0180db91511e2ce168670
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with: {fetch-depth: 1000}
+
+      - name: Git safe.directory
+        run: git config --global --add safe.directory $PWD
+
+      - name: Lint commits
+        run: conventional-tools commitlint -l1 -f39febd82e236a9c79f5b408e98cbd20410f11e9e

--- a/lua/ivy/libivy_test.lua
+++ b/lua/ivy/libivy_test.lua
@@ -10,9 +10,18 @@ end)
 
 it("should find a dot file", function(t)
   local current_dir = libivy.ivy_cwd()
-  local matches = libivy.ivy_files("ci.yml", current_dir)
+  local matches = libivy.ivy_files(".github/workflows/ci.yml", current_dir)
 
-  if matches ~= ".github/workflows/ci.yml\n" then
-    t.error("Invalid matches: " .. matches)
+  local results = {}
+  for line in string.gmatch(matches, "[^\r\n]+") do
+    table.insert(results, line)
+  end
+
+  if #results ~= 2 then
+    t.error "Incorrect number of results"
+  end
+
+  if results[2] ~= ".github/workflows/ci.yml" then
+    t.error("Invalid matches: " .. results[2])
   end
 end)


### PR DESCRIPTION
Migrate the conventional-tools docker image hosted on the dockerhub
