### PR TITLE
fix: opening terminal buffers

### DIFF
--- a/lua/ivy/utils.lua
+++ b/lua/ivy/utils.lua
@@ -17,6 +17,13 @@ utils.command_map = {
   [utils.actions.SPLIT] = "split",
 }
 
+utils.existing_command_map = {
+  [utils.actions.EDIT] = "buffer",
+  [utils.actions.CHECKPOINT] = "buffer",
+  [utils.actions.VSPLIT] = "vsplit | buffer",
+  [utils.actions.SPLIT] = "split | buffer",
+}
+
 utils.command_finder = function(command, min)
   if min == nil then
     min = 3
@@ -68,7 +75,14 @@ utils.file_action = function()
       return
     end
 
-    local command = utils.command_map[action]
+    local buffer_number = vim.fn.bufnr(file)
+    local command
+    if buffer_number > -1 then
+      command = utils.existing_command_map[action]
+    else
+      command = utils.command_map[action]
+    end
+
     if command == nil then
       vim.api.nvim_err_writeln("[IVY] The file action is unable the handel the action " .. action)
       return

--- a/lua/ivy/vim_mock.lua
+++ b/lua/ivy/vim_mock.lua
@@ -75,6 +75,11 @@ mock.reset = function()
         return lines
       end,
     },
+    fn = {
+      bufnr = function()
+        return -1
+      end,
+    },
     schedule = function(callback)
       callback()
     end,


### PR DESCRIPTION
Now when trying to open files and buffers it will use the `buffer` command when there is an existing buffer with the same name. This allows us to open non file buffers like terminals and log buffers.

By using the `bufnr` function to get the existing buffers, it will also work for buffers that have been renamed with `title` command

Ref: #31