### PR TITLE
Better shell commands

### DIFF
--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -37,7 +37,7 @@ controller.update = function(text)
     if #text > 0 then
       -- Escape characters so they do not throw an error when vim tries to use
       -- the "text" as a regex
-      local escaped_text = string.gsub(text, "([-/])", "\\%1")
+      local escaped_text = string.gsub(text, "([-/\\])", "\\%1")
       vim.cmd("syntax match IvyMatch '[" .. escaped_text .. "]'")
     end
   end)

--- a/lua/ivy/utils.lua
+++ b/lua/ivy/utils.lua
@@ -33,7 +33,7 @@ utils.command_finder = function(command, min)
     -- TODO(ade): Think if we want to start escaping the command here. I
     -- dont know if its causing issues while trying to use regex especially
     -- with word boundaries `input:gsub("'", "\\'"):gsub('"', '\\"')`
-    local handle = io.popen(command .. " " .. input .. " 2>&1")
+    local handle = io.popen(command .. " " .. input .. " 2>&1 || true")
     if handle == nil then
       return {}
     end

--- a/lua/ivy/utils.lua
+++ b/lua/ivy/utils.lua
@@ -38,7 +38,7 @@ utils.command_finder = function(command, min)
       return {}
     end
 
-    local results = {};
+    local results = {}
     for line in handle:lines() do
       table.insert(results, { content = line })
     end

--- a/lua/ivy/utils.lua
+++ b/lua/ivy/utils.lua
@@ -37,10 +37,14 @@ utils.command_finder = function(command, min)
     if handle == nil then
       return {}
     end
-    local result = handle:read "*a"
-    handle:close()
 
-    return result
+    local results = {};
+    for line in handle:lines() do
+      table.insert(results, { content = line })
+    end
+
+    handle:close()
+    return results
   end
 end
 


### PR DESCRIPTION
**fix: escape \ when running shell commands**

This is causing an issue when running shell commands though ivy and trying to escape chars is in strings or regexes.

**fix: never let a shell command fail**

This makes the terminal go really funkie and sometimes crash when printing the error messages to the current process stdout where nvim is running.

Now the error output is sent to the `popen` output and displayed in the ivy completion buffer without messing with the current process io.

**perf: return a table of results from the command finder**

When reading the output of a command we are now reading the stream line by line and building the table of results. This will save us a loop of the results later, if we returned a string we need to split the string before adding each line to the completion buffer because nvim only supports replacing one line at a time

