### PR TITLE
feat: add ripgrep backend

### DIFF
--- a/lua/ivy/backends/rg.lua
+++ b/lua/ivy/backends/rg.lua
@@ -1,0 +1,12 @@
+local utils = require "ivy.utils"
+
+local rg = {
+  name = "RG",
+  command = "IvyRg",
+  description = "Run ripgrep to search for content in files",
+  keymap = "<leader>/",
+  items = utils.command_finder "rg --vimgrep --",
+  callback = utils.vimgrep_action(),
+}
+
+return rg

--- a/plugin/ivy.lua
+++ b/plugin/ivy.lua
@@ -31,4 +31,10 @@ register_backend(require "ivy.backends.files")
 register_backend(require "ivy.backends.lines")
 register_backend(require "ivy.backends.lsp-workspace-symbols")
 
+if vim.fn.executable "rg" then
+  register_backend(require "ivy.backends.rg")
+elseif vim.fn.executable "ag" then
+  register_backend(require "ivy.backends.ag")
+end
+
 vim.cmd "highlight IvyMatch cterm=bold gui=bold"


### PR DESCRIPTION
`rg` will now be used over `ag` if it is available. This is because `rg` is a faster alternative reduces lag when searching larger codebases. `ag` is also now conditionally loaded if the command is available.