### PR TITLE
feat: add the paste functionality into the ivy prompt

### DIFF
--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -30,6 +30,10 @@ controller.search = function(value)
   controller.update(prompt.text())
 end
 
+controller.paste = function()
+  controller.search(prompt.text() .. vim.fn.getreg "+p")
+end
+
 controller.update = function(text)
   vim.schedule(function()
     window.set_items(controller.items(text))

--- a/plugin/ivy.lua
+++ b/plugin/ivy.lua
@@ -25,7 +25,17 @@ local register_backend = function(backend)
   end
 end
 
-register_backend(require "ivy.backends.ag")
+vim.paste = (function(overridden)
+  return function(lines, phase)
+    local file_type = vim.api.nvim_buf_get_option(0, "filetype")
+    if file_type == "ivy" then
+      vim.ivy.paste()
+    else
+      overridden(lines, phase)
+    end
+  end
+end)(vim.paste)
+
 register_backend(require "ivy.backends.buffers")
 register_backend(require "ivy.backends.files")
 register_backend(require "ivy.backends.lines")


### PR DESCRIPTION
Now when you paste and you are in an ivy buffer the paste will be added to the prompt not into the completion window. You can use your usual paste key binding I.E. `<SHIFT>+<INSERT> <CTRL>+<SHIFT>+<V>`

Ref: #11