### PR TITLE
refactor: remove lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,6 @@ dependencies = [
  "criterion",
  "fuzzy-matcher",
  "ignore",
- "lazy_static",
  "rayon",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ path = "rust/lib.rs"
 [dependencies]
 ignore = "0.4.20"
 fuzzy-matcher = "0.3.7"
-lazy_static = "1.4.0"
 rayon = "1.7.0"
 
 [dev-dependencies]

--- a/scripts/benchmark.lua
+++ b/scripts/benchmark.lua
@@ -1,5 +1,7 @@
 package.path = "lua/?.lua;" .. package.path
 local libivy = require "ivy.libivy"
+local vim_mock = require "ivy.vim_mock"
+local window = require "ivy.window"
 
 local benchmark = function(name, n, callback)
   local status = {
@@ -25,7 +27,7 @@ local benchmark = function(name, n, callback)
 
   print(
     string.format(
-      "| %-30s | %09.6f (s) | %09.6f (s) | %09.6f (s) | %09.6f (s) |",
+      "| %-41s | %09.6f (s) | %09.6f (s) | %09.6f (s) | %09.6f (s) |",
       name,
       status.running_total,
       status.running_total / n,
@@ -35,8 +37,8 @@ local benchmark = function(name, n, callback)
   )
 end
 
-print "| Name                           | Total         | Average       | Min           | Max           |"
-print "|--------------------------------|---------------|---------------|---------------|---------------|"
+print "| Name                                      | Total         | Average       | Min           | Max           |"
+print "|-------------------------------------------|---------------|---------------|---------------|---------------|"
 
 benchmark("ivy_match(file.lua) 1000000x", 1000000, function()
   libivy.ivy_match("file.lua", "some/long/path/to/file/file.lua")
@@ -45,4 +47,18 @@ end)
 libivy.ivy_init "/tmp/ivy-trees/kubernetes"
 benchmark("ivy_files(kubernetes) 100x", 100, function()
   libivy.ivy_files("file.go", "/tmp/ivy-trees/kubernetes")
+end)
+
+-- Mock the vim API so we can run `vim.` functions. Override the
+-- `nvim_buf_set_lines` function, this is so very slow. It saves all of the
+-- lines so we can assert on them in the tests. For benchmarking we don't need
+-- any of this, we can't control the vim internals.
+vim_mock.reset()
+_G.vim.api.nvim_buf_set_lines = function() end
+
+window.initialize()
+
+benchmark("ivy_files_with_set_items(kubernetes) 100x", 100, function()
+  local items = libivy.ivy_files(".go", "/tmp/ivy-trees/kubernetes")
+  window.set_items(items)
 end)


### PR DESCRIPTION
once_cell has now been merged into rust core. This removes the
lazy_static dependency and migrates over to the built in `OnceLock`.

Its always good to remove dependencies where possible, this also give us
a preference for the built in `OnceLock`

```
Benchmark 1: chore: add benchmark for `set_items`
  Time (mean ? ?):      6.327 s ?  0.199 s    [User: 15.316 s, System: 1.323 s]
  Range (min ? max):    6.087 s ?  6.712 s    10 runs

Benchmark 2: refactor: remove lazy_static
  Time (mean ? ?):      6.171 s ?  0.251 s    [User: 15.223 s, System: 1.382 s]
  Range (min ? max):    5.910 s ?  6.776 s    10 runs

Summary
  'refactor: remove lazy_static' ran
    1.03 ? 0.05 times faster than 'chore: add benchmark for `set_items`'
```

