### PR TITLE
perf: move to filter map from map and filter

### DIFF
--- a/rust/matcher.rs
+++ b/rust/matcher.rs
@@ -17,8 +17,7 @@ impl Matcher {
 
     pub fn score(&self, text: &str) -> i64 {
         self.matcher
-            .fuzzy_indices(text, &self.pattern)
-            .map(|(score, _indices)| score)
+            .fuzzy_match(text, &self.pattern)
             .unwrap_or_default()
     }
 }

--- a/rust/sorter.rs
+++ b/rust/sorter.rs
@@ -25,12 +25,19 @@ pub fn sort_strings(options: Options, strings: Vec<String>) -> Vec<Match> {
 
     let mut matches = strings
         .into_par_iter()
-        .map(|candidate| Match {
-            score: matcher.score(candidate.as_str()),
-            content: candidate,
+        .filter_map(|candidate| {
+            let score = matcher.score(candidate.as_str());
+            if score < options.minimum_score {
+                None
+            } else {
+                Some(Match {
+                    score,
+                    content: candidate,
+                })
+            }
         })
-        .filter(|m| m.score > options.minimum_score)
         .collect::<Vec<Match>>();
+
     matches.par_sort_unstable_by(|a, b| a.score.cmp(&b.score));
     matches
 }


### PR DESCRIPTION
Instead of doing two passes of all candidates using map then a filter, this uses `filter_map` so we are only doing one pass for the candidates. This alone is quite a significant improvement of around 7%

Output of `./scripts/bench 0.x`

```
Benchmark 1: 0.x
  Time (mean ± σ):      2.373 s ±  0.138 s    [User: 10.617 s, System: 1.697 s]
  Range (min … max):    2.124 s …  2.577 s    10 runs

Benchmark 2: HEAD
  Time (mean ± σ):      2.206 s ±  0.133 s    [User: 10.061 s, System: 1.811 s]
  Range (min … max):    1.940 s …  2.433 s    10 runs

Summary
  HEAD ran
    1.08 ± 0.09 times faster than 0.x

-------------------------------------
The percentage difference is -7.00%
-------------------------------------
```