### PR TITLE
feat: don't require a git directory to use .gitignore files

### DIFF
--- a/rust/finder.rs
+++ b/rust/finder.rs
@@ -10,7 +10,11 @@ pub fn find_files(options: Options) -> Vec<String> {
     let base_path = &fs::canonicalize(options.directory).unwrap();
 
     let mut builder = WalkBuilder::new(base_path);
+    // Search for hidden files and directories
     builder.hidden(false);
+    // Don't require a git repo to use .gitignore files. We want to use the .gitignore files
+    // wherever we are
+    builder.require_git(false);
 
     // TODO(ade): Remove unwraps and find a good way to get the errors into the UI. Currently there
     // is no way to handel errors in the rust library


### PR DESCRIPTION
feat: don't require a git directory to use .gitignore files

When we are searching we don't want to have to initialize git repo to use a
.gitignore file. This should just ignore any file in a .gitignore always

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/ivy.nvim/pull/69).
* #70
* __->__ #69