### PR TITLE
feat: don't search in sapling source control directories

### DIFF
--- a/rust/finder.rs
+++ b/rust/finder.rs
@@ -20,6 +20,7 @@ pub fn find_files(options: Options) -> Vec<String> {
     // is no way to handel errors in the rust library
     let mut override_builder = OverrideBuilder::new("");
     override_builder.add("!.git").unwrap();
+    override_builder.add("!.sl").unwrap();
 
     let overrides = override_builder.build().unwrap();
     builder.overrides(overrides);


### PR DESCRIPTION
feat: don't search in sapling source control directories

This file should be treated as the .git dir and not show up in the candidates
list for files.
