### PR TITLE
fix: opening file with square brackets in them

### DIFF
--- a/lua/ivy/utils.lua
+++ b/lua/ivy/utils.lua
@@ -104,7 +104,8 @@ utils.line_action = function()
 end
 
 utils.escape_file_name = function(input)
-  return string.gsub(input, "([$])", "\\%1")
+  local file, _ = string.gsub(input, "([$%]\\[])", "\\%1")
+  return file
 end
 
 return utils

--- a/lua/ivy/utils_escape_test.lua
+++ b/lua/ivy/utils_escape_test.lua
@@ -1,0 +1,11 @@
+local utils = require "ivy.utils"
+
+it("will escape a dollar in the file name", function(t)
+  local result = utils.escape_file_name "/path/to/$file/$name.lua"
+  t.assert_equal(result, "/path/to/\\$file/\\$name.lua")
+end)
+
+it("will escape a brackets in the file name", function(t)
+  local result = utils.escape_file_name "/path/to/[file]/[name].lua"
+  t.assert_equal(result, "/path/to/\\[file\\]/\\[name\\].lua")
+end)


### PR DESCRIPTION
fix: opening file with square brackets in them

Summary:

Fixes an issue where you could not open files that were already open with ivy.
If the file path contains a square brackets and that file is already loaded
into a buffer, ivy will throw an error when trying to open it via "files" or
"buffers".

This is an issue with the file escaping before we try and cal `buffer` passing
in the file path to go to the buffer rather than open a new buffer.

This is common with JS frameworks like next js for parameters in file based
routing.

Test Plan:

Test have been added for this change. I have also added tests for the dollar
that was previously handled.
