### PR TITLE
Implement setup function

### DIFF
--- a/lua/ivy/config.lua
+++ b/lua/ivy/config.lua
@@ -1,0 +1,33 @@
+local config_mt = {}
+config_mt.__index = config_mt
+
+function config_mt:get_in(config, key_table)
+  local current_value = config
+  for _, key in ipairs(key_table) do
+    if current_value == nil then
+      return nil
+    end
+
+    current_value = current_value[key]
+  end
+
+  return current_value
+end
+
+function config_mt:get(key_table)
+  return self:get_in(self.user_config, key_table) or self:get_in(self.default_config, key_table)
+end
+
+local config = { user_config = {} }
+
+config.default_config = {
+  backends = {
+    "ivy.backends.buffers",
+    "ivy.backends.files",
+    "ivy.backends.lines",
+    "ivy.backends.rg",
+    "ivy.backends.lsp-workspace-symbols",
+  },
+}
+
+return setmetatable(config, config_mt)

--- a/lua/ivy/config_spec.lua
+++ b/lua/ivy/config_spec.lua
@@ -1,0 +1,27 @@
+local config = require "ivy.config"
+
+describe("config", function()
+  before_each(function()
+    config.user_config = {}
+  end)
+
+  it("gets the first item when there is only default values", function()
+    local first_backend = config:get { "backends", 1 }
+    assert.is_equal("ivy.backends.buffers", first_backend)
+  end)
+
+  it("returns nil if we access a key that is not a valid config item", function()
+    assert.is_nil(config:get { "not", "a", "thing" })
+  end)
+
+  it("returns the users overridden config value", function()
+    config.user_config = { backends = { "ivy.my.backend" } }
+    local first_backend = config:get { "backends", 1 }
+    assert.is_equal("ivy.my.backend", first_backend)
+  end)
+
+  it("returns a nested value", function()
+    config.user_config = { some = { nested = "value" } }
+    assert.is_equal(config:get { "some", "nested" }, "value")
+  end)
+end)

--- a/lua/ivy/init.lua
+++ b/lua/ivy/init.lua
@@ -1,28 +1,32 @@
 local controller = require "ivy.controller"
+local config = require "ivy.config"
 local register_backend = require "ivy.register_backend"
-
--- Local variable to check if ivy has been setup, this is to prevent multiple
--- setups of ivy
-local has_setup = false
 
 local ivy = {}
 ivy.run = controller.run
 ivy.register_backend = register_backend
 
+-- Private variable to check if ivy has been setup, this is to prevent multiple
+-- setups of ivy. This is only exposed for testing purposes.
+---@private
+ivy.has_setup = false
+
 ---@class IvySetupOptions
 ---@field backends (IvyBackend | { ["1"]: string, ["2"]: IvyBackendOptions} | string)[]
 
----@param config IvySetupOptions
-function ivy.setup(config)
-  if has_setup then
+---@param user_config IvySetupOptions
+function ivy.setup(user_config)
+  if ivy.has_setup then
     return
   end
 
-  for _, backend in ipairs(config.backends) do
+  config.user_config = user_config or {}
+
+  for _, backend in ipairs(config:get { "backends" } or {}) do
     register_backend(backend)
   end
 
-  has_setup = true
+  ivy.has_setup = true
 end
 
 return ivy

--- a/lua/ivy/init.lua
+++ b/lua/ivy/init.lua
@@ -1,0 +1,28 @@
+local controller = require "ivy.controller"
+local register_backend = require "ivy.register_backend"
+
+-- Local variable to check if ivy has been setup, this is to prevent multiple
+-- setups of ivy
+local has_setup = false
+
+local ivy = {}
+ivy.run = controller.run
+ivy.register_backend = register_backend
+
+---@class IvySetupOptions
+---@field backends (IvyBackend | { ["1"]: string, ["2"]: IvyBackendOptions} | string)[]
+
+---@param config IvySetupOptions
+function ivy.setup(config)
+  if has_setup then
+    return
+  end
+
+  for _, backend in ipairs(config.backends) do
+    register_backend(backend)
+  end
+
+  has_setup = true
+end
+
+return ivy

--- a/lua/ivy/init_spec.lua
+++ b/lua/ivy/init_spec.lua
@@ -1,0 +1,30 @@
+local ivy = require "ivy"
+local config = require "ivy.config"
+
+describe("ivy.setup", function()
+  before_each(function()
+    ivy.has_setup = false
+    config.user_config = {}
+  end)
+
+  it("sets the users config options", function()
+    ivy.setup { backends = { "ivy.backends.files" } }
+    assert.is_equal("ivy.backends.files", config:get { "backends", 1 })
+  end)
+
+  it("will not reconfigure if its called twice", function()
+    ivy.setup { backends = { "ivy.backends.files" } }
+    ivy.setup { backends = { "some.backend" } }
+    assert.is_equal("ivy.backends.files", config:get { "backends", 1 })
+  end)
+
+  it("does not crash if you don't pass in any params to the setup function", function()
+    ivy.setup()
+    assert.is_equal("ivy.backends.buffers", config:get { "backends", 1 })
+  end)
+
+  it("will fallback if the key is not set at all in the users config", function()
+    ivy.setup { some_key = "some_value" }
+    assert.is_equal("ivy.backends.buffers", config:get { "backends", 1 })
+  end)
+end)

--- a/lua/ivy/register_backend.lua
+++ b/lua/ivy/register_backend.lua
@@ -1,0 +1,54 @@
+---@class IvyBackend
+---@field command string The command this backend will have
+---@field items fun(input: string): { content: string }[] | string The callback function to get the items to select from
+---@field callback fun(result: string, action: string) The callback function to run when a item is selected
+---@field description string? The description of the backend, this will be used in the keymaps
+---@field name string? The name of the backend, this will fallback to the command if its not set
+---@field keymap string? The keymap to trigger this backend
+
+---@class IvyBackendOptions
+---@field command string The command this backend will have
+---@field keymap string? The keymap to trigger this backend
+
+---Register a new backend
+---
+---This will create all the commands and set all the keymaps for the backend
+---@param backend IvyBackend
+local register_backend_class = function(backend)
+  local user_command_options = { bang = true }
+  if backend.description ~= nil then
+    user_command_options.desc = backend.description
+  end
+
+  local name = backend.name or backend.command
+  vim.api.nvim_create_user_command(backend.command, function()
+    vim.ivy.run(name, backend.items, backend.callback)
+  end, user_command_options)
+
+  if backend.keymap ~= nil then
+    vim.api.nvim_set_keymap("n", backend.keymap, "<cmd>" .. backend.command .. "<CR>", { nowait = true, silent = true })
+  end
+end
+
+---@param backend IvyBackend | { ["1"]: string, ["2"]: IvyBackendOptions} | string The backend or backend module
+---@param options IvyBackendOptions? The options for the backend, that will be merged with the backend
+local register_backend = function(backend, options)
+  if type(backend[1]) == "string" then
+    options = backend[2]
+    backend = require(backend[1])
+  end
+
+  if type(backend) == "string" then
+    backend = require(backend)
+  end
+
+  if options then
+    for key, value in pairs(options) do
+      backend[key] = value
+    end
+  end
+
+  register_backend_class(backend)
+end
+
+return register_backend

--- a/lua/ivy/register_backend_spec.lua
+++ b/lua/ivy/register_backend_spec.lua
@@ -1,0 +1,71 @@
+local register_backend = require "ivy.register_backend"
+
+local function get_command(name)
+  local command_iter = vim.api.nvim_get_commands {}
+
+  for _, cmd in pairs(command_iter) do
+    if cmd.name == name then
+      return cmd
+    end
+  end
+
+  return nil
+end
+
+local function get_keymap(mode, rhs)
+  local keymap_iter = vim.api.nvim_get_keymap(mode)
+  for _, keymap in pairs(keymap_iter) do
+    if keymap.rhs == rhs then
+      return keymap
+    end
+  end
+
+  return nil
+end
+
+describe("register_backend", function()
+  after_each(function()
+    vim.api.nvim_del_user_command "IvyFd"
+
+    local keymap = get_keymap("n", "<Cmd>IvyFd<CR>")
+    if keymap then
+      vim.api.nvim_del_keymap("n", keymap.lhs)
+    end
+  end)
+
+  it("registers a backend from a string with the default options", function()
+    register_backend "ivy.backends.files"
+
+    local command = get_command "IvyFd"
+    assert.is_not_nil(command)
+
+    local keymap = get_keymap("n", "<Cmd>IvyFd<CR>")
+    assert.is_not_nil(keymap)
+  end)
+
+  it("allows you to override the keymap", function()
+    register_backend("ivy.backends.files", { keymap = "<C-p>" })
+
+    local keymap = get_keymap("n", "<Cmd>IvyFd<CR>")
+    assert(keymap ~= nil)
+    assert.are.equal("<C-P>", keymap.lhs)
+  end)
+
+  it("allows you to pass in a hole backend module", function()
+    register_backend(require "ivy.backends.files")
+
+    local command = get_command "IvyFd"
+    assert.is_not_nil(command)
+
+    local keymap = get_keymap("n", "<Cmd>IvyFd<CR>")
+    assert.is_not_nil(keymap)
+  end)
+
+  it("allows you to pass in a hole backend module", function()
+    register_backend { "ivy.backends.files", { keymap = "<C-p>" } }
+
+    local keymap = get_keymap("n", "<Cmd>IvyFd<CR>")
+    assert(keymap ~= nil)
+    assert.are.equal("<C-P>", keymap.lhs)
+  end)
+end)

--- a/plugin/ivy.lua
+++ b/plugin/ivy.lua
@@ -1,29 +1,10 @@
 local controller = require "ivy.controller"
+local register_backend = require "ivy.register_backend"
 
 -- Put the controller in to the vim global so we can access it in mappings
 -- better without requires. You can call controller commands like `vim.ivy.xxx`.
 -- luacheck: ignore
 vim.ivy = controller
-
-local register_backend = function(backend)
-  assert(backend.command, "The backend must have a command")
-  assert(backend.items, "The backend must have a items function")
-  assert(backend.callback, "The backend must have a callback function")
-
-  local user_command_options = { bang = true }
-  if backend.description ~= nil then
-    user_command_options.desc = backend.description
-  end
-
-  local name = backend.name or backend.command
-  vim.api.nvim_create_user_command(backend.command, function()
-    vim.ivy.run(name, backend.items, backend.callback)
-  end, user_command_options)
-
-  if backend.keymap ~= nil then
-    vim.api.nvim_set_keymap("n", backend.keymap, "<cmd>" .. backend.command .. "<CR>", { nowait = true, silent = true })
-  end
-end
 
 vim.paste = (function(overridden)
   return function(lines, phase)
@@ -36,15 +17,15 @@ vim.paste = (function(overridden)
   end
 end)(vim.paste)
 
-register_backend(require "ivy.backends.buffers")
-register_backend(require "ivy.backends.files")
-register_backend(require "ivy.backends.lines")
-register_backend(require "ivy.backends.lsp-workspace-symbols")
+register_backend "ivy.backends.buffers"
+register_backend "ivy.backends.files"
+register_backend "ivy.backends.lines"
+register_backend "ivy.backends.lsp-workspace-symbols"
 
 if vim.fn.executable "rg" then
-  register_backend(require "ivy.backends.rg")
+  register_backend "ivy.backends.rg"
 elseif vim.fn.executable "ag" then
-  register_backend(require "ivy.backends.ag")
+  register_backend "ivy.backends.ag"
 end
 
 vim.cmd "highlight IvyMatch cterm=bold gui=bold"

--- a/plugin/ivy.lua
+++ b/plugin/ivy.lua
@@ -1,5 +1,4 @@
 local controller = require "ivy.controller"
-local register_backend = require "ivy.register_backend"
 
 -- Put the controller in to the vim global so we can access it in mappings
 -- better without requires. You can call controller commands like `vim.ivy.xxx`.
@@ -16,16 +15,5 @@ vim.paste = (function(overridden)
     end
   end
 end)(vim.paste)
-
-register_backend "ivy.backends.buffers"
-register_backend "ivy.backends.files"
-register_backend "ivy.backends.lines"
-register_backend "ivy.backends.lsp-workspace-symbols"
-
-if vim.fn.executable "rg" then
-  register_backend "ivy.backends.rg"
-elseif vim.fn.executable "ag" then
-  register_backend "ivy.backends.ag"
-end
 
 vim.cmd "highlight IvyMatch cterm=bold gui=bold"


### PR DESCRIPTION
Summary:

Now when using ivy.nvim you will need to call the `setup` function. This will
need to register any backends you want to use. This is an example config, this
can be put into a plugin in `~/.config/nvim/plugin/ivy.lua` for example.

```lua
require('ivy').setup {
  backends = {
    "ivy.backends.buffers",
    "ivy.backends.files",
  },
}
```

If you are using Lazy you can use the `config` directly to call the setup
function.

```lua
return {
  "AdeAttwood/ivy.nvim",
  build = "cargo build --release",
  config = {
    backends = {
      "ivy.backends.buffers",
      "ivy.backends.files",
    }
  }
}
```

The `setup` function can only be called once, if its called a second time any
backends or config will not be used. The module does expose the
`register_backend` function, this can be used to load backends before or after
the setup function is called.

```lua
require('ivy').register_backend("ivy.backends.files")
```

As well as the `register_backend` the core `run`function is exposed. With this
exposed we should be able to build anything we want.

```lua
vim.ivy.run(
  "Title",
  function(input)
    return {
      { content = "One" },
      { content = "Two" },
      { content = "Three" },
    }
  end,
  function(result) vim.cmd("edit " .. result) end
)
```

Test Plan:

Not much to test in this one, it has been tested locally on my config that does
not use any plugin managers, also a sandbox Lazy env using `NVIM_APPNAME`
NVIM_APPNAME

Testing with a manual setup:

```lua
require('ivy').setup {
  backends = {
    "ivy.backends.buffers",
    "ivy.backends.files",
  },
}
```

Testing with Lazy:

```lua
require("lazy").setup({
  {
    "AdeAttwood/ivy.nvim",
    branch = "adeattwood/setup-function",
    build = "cargo build --release",
    config = {
      backends = {
        { "ivy.backends.files", { keymap = "<C-p>" } },
      },
    },
  },
})
```