### PR TITLE
ci: update the test command for better output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,4 @@ jobs:
           export VIM="${PWD}/_neovim/share/nvim/runtime"
 
           nvim --version
-          nvim -l ./scripts/busted.lua ./lua
+          nvim -l ./scripts/busted.lua -o TAP ./lua/ivy/ 2> /dev/null


### PR DESCRIPTION
Summary:

Now we are running the tests in neovim we get some output printed to stderr. This is not helpful in the test output, and obfuscate errors.

This throws any unneeded output to `/dev/null` so we can focus of the tests that have failed. It also moves over to using TAP output for a more descriptive out put in CI.

Test Plan:

CI, running the test will validate this