### PR TITLE
fix: panic on files you don't have access to

### DIFF
--- a/rust/finder.rs
+++ b/rust/finder.rs
@@ -26,7 +26,11 @@ pub fn find_files(options: Options) -> Vec<String> {
     builder.overrides(overrides);
 
     for result in builder.build() {
-        let absolute_candidate = result.unwrap();
+        let absolute_candidate = match result {
+            Ok(absolute_candidate) => absolute_candidate,
+            Err(..) => continue,
+        };
+
         let candidate_path = absolute_candidate.path().strip_prefix(base_path).unwrap();
         if candidate_path.is_dir() {
             continue;


### PR DESCRIPTION
Summary:

When you are in a project that has files the user cannot read, ivy's finder will panic will a permission denied error. This can quite easily happen when using docker on a project, it's quite common to mount a directory into a docker container that is run as a different user I.E. MySQL. The other example I can think of is when you are running tests in a container, the test output may be owned by the containers' user.

When running ivy this is an example of the kind of panic you would get.

```
thread '<unnamed>' panicked at rust/finder.rs:34:41:
  called `Result::unwrap()` on an `Err` value: WithPath {
    path: "/tmp/workspace/mysql/#innodb_redo", err: Io(
      Custom {
        kind: PermissionDenied, error: Error {
          depth: 2, inner: Io {
            path: Some("/tmp/workspace/mysql/#innodb_redo"),
            err: Os {
              code: 13,
              kind: PermissionDenied,
              message: "Permission denied"
            }
          }
        }
      }
    )
  }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: Rust panics must be rethrown
```

Ref: #83

Test Plan:

This has been tested locally, right now we don't have any unit tests for this. We may setup some more testing in the future. This was a little hard to recreate with out docker and mysql.