### PR TITLE
ci: run tests on more versions of nvim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
 
   test:
     name: Build and test
+    strategy:
+      matrix:
+        nvim-version: ["v0.9.5", "stable", "nightly"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -70,7 +73,7 @@ jobs:
         run: |
           test -d _neovim || {
             mkdir -p _neovim
-            curl -sL "https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+            curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.nvim-version }}/nvim-linux64.tar.gz" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
           }
 
       - name: Build


### PR DESCRIPTION

Summary:

Right now we are only running the tests on the nightly build of nvim. I would
like to try and maintain support for a few releases. One of the goals of this
project is to be stable. This means trying our best to maintain BC, for this I
have setup running the tests on older versions of nvim.

Right now we have:

- *nightly* Make sure we support the new releases, we can hopefully fix issues
  before this gets releases.
- *stable* This is the main version we support
- *v0.9.5* Maintain the old stable, some OSs like Ubuntu lack behind, would be
  nice to maintain that.

Test Plan:

CI, I have done a quick run before finalizing the change
