### PR TITLE
ci: run stylua via npx rather than via action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run stylua
-        uses: JohnnyMorganz/stylua-action@v4.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: latest
-          args: --check .
+        run: npx @johnnymorganz/stylua-bin --check .
 
   cargo-format:
     name: Cargo Format


### PR DESCRIPTION
Summary:

This is so we don't need the GITHUB_TOKEN that can not be added in forgejo. I am giving it a go and the `GITHUB_` prefix is reserved for secrets. There are also issues with the action in a forgejo environment due to the API not resolving to github.

This now should work on both platforms. So we can maintain github compatibility for any pull requests that may come that way.

Test Plan:

Run the CI on github and forgejo, this will need to be a manual process to validate this works.