### PR TITLE
fix: crash when running IvyLines

### DIFF
--- a/lua/ivy/backends/lines.lua
+++ b/lua/ivy/backends/lines.lua
@@ -4,7 +4,7 @@ local libivy = require "ivy.libivy"
 local function items(input)
   local list = {}
 
-  local lines = vim.api.nvim_buf_get_lines(vim.ivy.origin(), 0, -1, false)
+  local lines = vim.api.nvim_buf_get_lines(vim.ivy.origin_buffer(), 0, -1, false)
   for index = 1, #lines do
     local line = lines[index]
     local score = libivy.ivy_match(input, line)

--- a/lua/ivy/backends/lines_spec.lua
+++ b/lua/ivy/backends/lines_spec.lua
@@ -1,0 +1,51 @@
+local config = require "ivy.config"
+local ivy = require "ivy"
+local window = require "ivy.window"
+
+describe("backends/lines", function()
+  before_each(function()
+    vim.cmd "highlight IvyMatch cterm=bold gui=bold"
+    config.user_config = {}
+    _G.vim.ivy = ivy
+
+    ivy.setup()
+  end)
+
+  before_each(function()
+    vim.cmd "edit /tmp/test.txt"
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      "Line one",
+      "Line two",
+      "Line three",
+    })
+
+    vim.cmd "IvyLines"
+    vim.wait(0)
+  end)
+
+  after_each(function()
+    ivy.destroy()
+    vim.api.nvim_buf_delete(0, { force = true })
+  end)
+
+  it("will give the buffer the correct name", function()
+    local buf_name = vim.api.nvim_buf_get_name(window.buffer)
+    assert.is_true(vim.endswith(buf_name, "Lines"))
+  end)
+
+  it("will show all the lines in the file when nothing is selected", function()
+    local lines = vim.api.nvim_buf_get_lines(window.buffer, 0, -1, false)
+    assert.is_equal(#lines, 3)
+  end)
+
+  it("will sort the buffer when there is a selection", function()
+    vim.ivy.search "three"
+    vim.wait(0)
+
+    local lines = vim.api.nvim_buf_get_lines(window.buffer, 0, -1, false)
+    assert.is_equal(#lines, 3)
+
+    local selection = window.get_current_selection()
+    assert.is_equal(selection, "   3: Line three")
+  end)
+end)

--- a/lua/ivy/backends/lsp-workspace-symbols.lua
+++ b/lua/ivy/backends/lsp-workspace-symbols.lua
@@ -8,7 +8,7 @@ local function set_items(items)
 end
 
 local function items(input)
-  local buffer_number = window.origin_buffer
+  local buffer_number = vim.ivy.origin_buffer()
   local cwd = vim.fn.getcwd()
   local results = {}
   vim.lsp.buf_request(buffer_number, "workspace/symbol", { query = input }, function(err, server_result, _, _)

--- a/lua/ivy/controller.lua
+++ b/lua/ivy/controller.lua
@@ -79,6 +79,14 @@ controller.previous = function()
 end
 
 controller.origin = function()
+  return controller.origin_window()
+end
+
+controller.origin_window = function()
+  return window.origin
+end
+
+controller.origin_buffer = function()
   return vim.api.nvim_win_get_buf(window.origin)
 end
 

--- a/lua/ivy/init.lua
+++ b/lua/ivy/init.lua
@@ -22,6 +22,8 @@ ivy.input = controller.input
 ivy.next = controller.next
 ivy.previous = controller.previous
 ivy.search = controller.search
+ivy.origin_buffer = controller.origin_buffer
+ivy.origin_window = controller.origin_window
 
 -- Private variable to check if ivy has been setup, this is to prevent multiple
 -- setups of ivy. This is only exposed for testing purposes.

--- a/lua/ivy/window.lua
+++ b/lua/ivy/window.lua
@@ -63,7 +63,6 @@ window.index = 0
 window.origin = nil
 window.window = nil
 window.buffer = nil
-window.origin_buffer = nil
 
 window.initialize = function()
   window.make_buffer()
@@ -71,7 +70,6 @@ end
 
 window.make_buffer = function()
   window.origin = vim.api.nvim_get_current_win()
-  window.origin_buffer = vim.api.nvim_win_get_buf(0)
 
   vim.api.nvim_command "botright split new"
   window.buffer = vim.api.nvim_win_get_buf(0)
@@ -170,7 +168,6 @@ window.destroy = function()
   window.buffer = nil
   window.window = nil
   window.origin = nil
-  window.origin_buffer = nil
   window.index = 0
 end
 


### PR DESCRIPTION
As well as fixing the actual issue, this updates the public origin api's to be more consistent. We now have:

- **origin_buffer** This will return the buffer that ivy was called from
- **origin_window** This will return the window that the origin was called from

Fixes: #97