### PR TITLE
feat: allow the user to use lua functions as mappings

### DIFF
--- a/lua/ivy/window.lua
+++ b/lua/ivy/window.lua
@@ -57,6 +57,18 @@ local callbacks = {
   delete_word = "<cmd>lua vim.ivy.input('DELETE_WORD')<CR>",
 }
 
+local function get_mapping_function(key)
+  if type(key) == "function" then
+    return key
+  end
+
+  if callbacks[key] == nil then
+    error("The mapping '" .. key .. "' is not a valid ivy callback")
+  end
+
+  return callbacks[key]
+end
+
 local window = {}
 
 window.index = 0
@@ -96,11 +108,8 @@ window.make_buffer = function()
   local mappings = config:get { "mappings" }
   assert(mappings, "The mappings key is missing from the config, something has gone horribly wrong")
   for key, value in pairs(mappings) do
-    if callbacks[value] == nil then
-      error("The mapping '" .. value .. "' is not a valid ivy callback")
-    end
-
-    vim.api.nvim_buf_set_keymap(window.buffer, "n", key, callbacks[value], opts)
+    local callback = get_mapping_function(value)
+    vim.keymap.set({ "n" }, key, callback, vim.tbl_extend("force", opts, { buffer = window.buffer }))
   end
 end
 

--- a/lua/ivy/window_spec.lua
+++ b/lua/ivy/window_spec.lua
@@ -1,17 +1,24 @@
 local window = require "ivy.window"
 local controller = require "ivy.controller"
+local config = require "ivy.config"
+local ivy = require "ivy"
 
 describe("window", function()
   before_each(function()
+    _G.vim.ivy = ivy
     vim.cmd "highlight IvyMatch cterm=bold gui=bold"
-    window.initialize()
   end)
 
   after_each(function()
     controller.destroy()
+
+    config.user_config = {}
+    ivy.has_setup = false
   end)
 
   it("can initialize and destroy the window", function()
+    window.initialize()
+
     assert.is_equal(vim.api.nvim_get_current_buf(), window.buffer)
 
     window.destroy()
@@ -19,14 +26,52 @@ describe("window", function()
   end)
 
   it("can set items", function()
+    window.initialize()
+
     window.set_items { { content = "Line one" } }
     assert.is_equal("Line one", window.get_current_selection())
   end)
 
   it("will set the items when a string is passed in", function()
+    window.initialize()
+
     local items = table.concat({ "One", "Two", "Three" }, "\n")
     window.set_items(items)
 
     assert.is_equal(items, table.concat(vim.api.nvim_buf_get_lines(window.buffer, 0, -1, true), "\n"))
+  end)
+
+  it("will error on invalid mapping callback", function()
+    ivy.setup {
+      mappings = {
+        ["<CR>"] = "invalid_callback",
+      },
+    }
+
+    assert.has_error(function()
+      window.initialize()
+    end, "The mapping 'invalid_callback' is not a valid ivy callback")
+  end)
+
+  it("will accept function callbacks", function()
+    local was_called = false
+    local test_fn = function()
+      was_called = true
+    end
+
+    ivy.setup {
+      mappings = {
+        ["<C-1>"] = test_fn,
+      },
+    }
+
+    vim.cmd "IvyLines"
+
+    vim.wait(0)
+
+    -- Trigger the mapping
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-1>", true, false, true), "x", true)
+
+    assert.is_true(was_called)
   end)
 end)


### PR DESCRIPTION
Previously you were only allowed to have a predefined list of mappings. They were provided as strings. Sometimes you could not quite do what you wanted to do.

This now allows you to add functions as the mappings along with the predefined string. Its still recommended to use the strings however, if you are working on a plugin or need to do something that is not quite recommended then you can use a lua function.

You will do this just like you add the strings in your setup function.

```lua
require("ivy").setup {
  mappings = {
    ["<CR>"] = function ()
      -- To stuff
    end
  }
}
```

Ref: #98