### PR TITLE
feat: add command history backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ customized when you register it.
 | `ivy.backends.buffers`               | IvyBuffers         | \<leader\>b     | Search though open buffers                                  |
 | `ivy.backends.lines`                 | IvyLines           |                 | Search the lines in the current buffer                      |
 | `ivy.backends.lsp-workspace-symbols` | IvyWorkspaceSymbol |                 | Search for workspace symbols using the lsp workspace/symbol |
+| `ivy.backends.cmd-history`           | IvyCmdHistory      | \<c-r\>         | Search though your command history                          |
 
 ### Actions
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ customized when you register it.
 | `ivy.backends.files`                 | IvyFd              | \<leader\>p     | Find files in your project with a custom rust file finder   |
 | `ivy.backends.ag`                    | IvyAg              | \<leader\>/     | Find content in files using the silver searcher             |
 | `ivy.backends.rg`                    | IvyRg              | \<leader\>/     | Find content in files using ripgrep cli tool                |
-| `ivy.backends.buffers`               | IvyBuffers         | \<leader\>b     | Search though open buffers                                  |
+| `ivy.backends.buffers`               | IvyBuffers         | \<leader\>b     | Search through open buffers                                 |
 | `ivy.backends.lines`                 | IvyLines           |                 | Search the lines in the current buffer                      |
 | `ivy.backends.lsp-workspace-symbols` | IvyWorkspaceSymbol |                 | Search for workspace symbols using the lsp workspace/symbol |
-| `ivy.backends.cmd-history`           | IvyCmdHistory      | \<c-r\>         | Search though your command history                          |
+| `ivy.backends.cmd-history`           | IvyCmdHistory      | \<c-r\>         | Search through your command history                         |
 
 ### Actions
 

--- a/lua/ivy/backends/cmd-history.lua
+++ b/lua/ivy/backends/cmd-history.lua
@@ -1,0 +1,36 @@
+local libivy = require "ivy.libivy"
+
+local cmd_history = {
+  name = "CmdHistory",
+  command = "IvyCmdHistory",
+  description = "Search though your command history",
+  keymap = "<c-r>",
+}
+
+cmd_history.items = function(input)
+  local list = {}
+  local history_list = vim.split(vim.fn.execute "history cmd", "\n")
+
+  for index = 1, #history_list do
+    local offset, line = string.match(history_list[index], "^%s+(%d+)%s+(.+)")
+
+    if line then
+      local score = libivy.ivy_match(input, line)
+      if score > 50 then
+        table.insert(list, { score = score + tonumber(offset), content = line })
+      end
+    end
+  end
+
+  table.sort(list, function(a, b)
+    return a.score < b.score
+  end)
+
+  return list
+end
+
+cmd_history.callback = function(item)
+  vim.cmd(item)
+end
+
+return cmd_history


### PR DESCRIPTION
Summary:

Now when this backend is enabled you can search though your command history. The default keybinding for this is `<ctrl-r>`, this is the same biding you would expect from emacs bindings in bash.

Test Plan:

Not tests for this. I have been using this quite a lot locally.