### PR TITLE
ci: add Neovim 0.10 and 0.11 to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,12 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        download: ["v0.9.5/nvim-linux64.tar.gz", "stable/nvim-linux-x86_64.tar.gz", "nightly/nvim-linux-x86_64.tar.gz"]
+        download:
+          - "v0.9.5/nvim-linux64.tar.gz"
+          - "v0.10.4/nvim-linux-x86_64.tar.gz"
+          - "v0.11.7/nvim-linux-x86_64.tar.gz"
+          - "stable/nvim-linux-x86_64.tar.gz"
+          - "nightly/nvim-linux-x86_64.tar.gz"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/lua/ivy/backends/lines_spec.lua
+++ b/lua/ivy/backends/lines_spec.lua
@@ -20,7 +20,7 @@ describe("backends/lines", function()
     })
 
     vim.cmd "IvyLines"
-    vim.wait(0)
+    vim.wait(1)
   end)
 
   after_each(function()
@@ -40,7 +40,7 @@ describe("backends/lines", function()
 
   it("will sort the buffer when there is a selection", function()
     vim.ivy.search "three"
-    vim.wait(0)
+    vim.wait(1)
 
     local lines = vim.api.nvim_buf_get_lines(window.buffer, 0, -1, false)
     assert.is_equal(#lines, 3)

--- a/lua/ivy/controller_spec.lua
+++ b/lua/ivy/controller_spec.lua
@@ -19,7 +19,7 @@ describe("controller", function()
     end)
 
     -- Run all the scheduled tasks
-    vim.wait(0)
+    vim.wait(1)
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
     assert.is_equal(#lines, 1)
@@ -35,7 +35,7 @@ describe("controller", function()
 
     controller.update ""
 
-    vim.wait(0)
+    vim.wait(1)
 
     assert.spy(vim.cmd).was_called_with "syntax clear IvyMatch"
     assert.spy(vim.cmd).was_not_called_with "syntax match IvyMatch '[H]'"
@@ -50,7 +50,7 @@ describe("controller", function()
 
     controller.update "some-file"
 
-    vim.wait(0)
+    vim.wait(1)
 
     assert.spy(vim.cmd).was_called_with "syntax match IvyMatch '[some\\-file]'"
   end)

--- a/lua/ivy/window_spec.lua
+++ b/lua/ivy/window_spec.lua
@@ -67,7 +67,7 @@ describe("window", function()
 
     vim.cmd "IvyLines"
 
-    vim.wait(0)
+    vim.wait(1)
 
     -- Trigger the mapping
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-1>", true, false, true), "x", true)


### PR DESCRIPTION

Summary:

Extend the CI Neovim test matrix so supported maintenance
releases 0.10 and 0.11 continue to run alongside the minimum
supported 0.9.5 release, stable 0.12, and nightly. This gives CI
coverage for the latest patch versions before stable moved to the
0.12 release line.

Test Plan:

1. Run `git diff --check --cached -- ".github/workflows/ci.yml"`.
