### PR TITLE
perf: batch Ivy window item rendering

### DIFF
--- a/lua/ivy/window.lua
+++ b/lua/ivy/window.lua
@@ -152,9 +152,11 @@ window.set_items = function(items)
 
   window.index = items_length - 1
 
+  local lines = {}
   for index = 1, items_length do
-    vim.api.nvim_buf_set_lines(window.buffer, index - 1, -1, false, { items[index].content })
+    lines[index] = items[index].content
   end
+  vim.api.nvim_buf_set_lines(window.buffer, 0, -1, false, lines)
 
   -- Limit the results window size to 10 so when there are lots of results the
   -- window does not take up the hole terminal


### PR DESCRIPTION

Summary:

Batch window item rendering so large Ivy result sets update the buffer
with a single Neovim API call. This keeps selection behavior unchanged
while reducing per-result overhead in ivy_files_with_set_items(kubernetes).

The benchmark run reported `ivy_files_with_set_items(kubernetes) 100x`
at 0.020985s average, down from the accepted 0.035224s median
baseline. That is about a 40.4% improvement.

Test Plan:

1. Run `cargo build --release`.
2. Run `nvim --clean --noplugin -u NONE -i NONE -n -l ./scripts/busted.lua ./lua/ivy/`.
3. Run `nvim --clean --noplugin -u NONE -i NONE -n -l ./scripts/benchmark.lua`.
