### PR TITLE
perf: avoid cloning cached file paths

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -97,18 +97,28 @@ pub extern "C" fn ivy_files_iter(c_pattern: *const c_char, c_base_dir: *const c_
     let directory = to_string(c_base_dir);
     let pattern = to_string(c_pattern);
 
-    let files = get_files(&directory);
-
     let mut ivy = Ivy::global().lock().unwrap();
+
+    if !ivy.file_cache.contains_key(&directory) {
+        let finder_options = finder::Options {
+            directory: directory.clone(),
+        };
+
+        ivy.file_cache
+            .insert(directory.clone(), finder::find_files(finder_options));
+    }
 
     // Convert the matches into CStrings so we can pass the pointers out while still maintaining
     // ownership. If we didn't do this the CString would be dropped and the pointer would be freed
     // while its being used externally.
     let sorter_options = sorter::Options::new(pattern);
-    let matches = sorter::sort_strings(sorter_options, files)
-        .into_iter()
-        .map(|m| CString::new(m.content.as_str()).unwrap())
-        .collect::<Vec<CString>>();
+    let matches = {
+        let files = ivy.file_cache.get(&directory).unwrap();
+        sorter::sort_strings(sorter_options, files)
+            .into_iter()
+            .map(|m| CString::new(m.content).unwrap())
+            .collect::<Vec<CString>>()
+    };
 
     ivy.iter_sequence += 1;
     let new_sequence = ivy.iter_sequence;
@@ -169,7 +179,7 @@ pub fn inner_files(pattern: String, base_dir: String) -> String {
 
     let sorter_options = sorter::Options::new(pattern);
 
-    let files = sorter::sort_strings(sorter_options, files);
+    let files = sorter::sort_strings(sorter_options, &files);
     for file in files.iter() {
         output.push_str(&file.content);
         output.push('\n');

--- a/rust/sorter.rs
+++ b/rust/sorter.rs
@@ -1,9 +1,9 @@
 use super::matcher;
 use rayon::prelude::*;
 
-pub struct Match {
+pub struct Match<'a> {
     pub score: i64,
-    pub content: String,
+    pub content: &'a str,
 }
 
 pub struct Options {
@@ -20,11 +20,11 @@ impl Options {
     }
 }
 
-pub fn sort_strings(options: Options, strings: Vec<String>) -> Vec<Match> {
+pub fn sort_strings(options: Options, strings: &[String]) -> Vec<Match<'_>> {
     let matcher = matcher::Matcher::new(options.pattern);
 
     let mut matches = strings
-        .into_par_iter()
+        .par_iter()
         .filter_map(|candidate| {
             let score = matcher.score(candidate.as_str());
             if score < options.minimum_score {
@@ -32,7 +32,7 @@ pub fn sort_strings(options: Options, strings: Vec<String>) -> Vec<Match> {
             } else {
                 Some(Match {
                     score,
-                    content: candidate,
+                    content: candidate.as_str(),
                 })
             }
         })


### PR DESCRIPTION

Summary:

Improve Ivy file search rendering by sorting borrowed cached paths
instead of cloning the cached Kubernetes file list for each iterator
query. The target benchmark
`ivy_files_with_set_items(kubernetes) 100x` improved from the
accepted 0.021151s median baseline to 0.018411s average in the
autoresearch run, about 12.95% faster. Behavior is unchanged because
matched paths are still copied into CStrings before crossing the Lua
FFI boundary.

Test Plan:

1. Run `cargo build --release`.
2. Run `nvim --clean --noplugin -u NONE -i NONE -n -l ./scripts/busted.lua ./lua/ivy/`.
3. Run `nvim --clean --noplugin -u NONE -i NONE -n -l ./scripts/benchmark.lua`.
